### PR TITLE
Fix NoneType has not attribute error

### DIFF
--- a/spray365.py
+++ b/spray365.py
@@ -736,8 +736,12 @@ def spray_execution_plan(args):
         result = cred.authenticate(proxy_url, args.insecure)
         auth_results.append(result)
 
-        if result.auth_error and result.auth_error.error_code == 50053:
-            global_lockouts_observed += 1
+        # When auth is successful under certain conditions, auth_error is none
+        if result.auth_error is None:
+            pass
+        else:
+            if result.auth_error and result.auth_error.error_code == 50053:
+                global_lockouts_observed += 1
 
         if lockout_threshold and global_lockouts_observed >= lockout_threshold:
             print_error("Lockout threshold reached, aborting password spray")


### PR DESCRIPTION
Here is my proposed fix.  In some cases authentication success does not have a result.auth_erorr.  Therefore it was failing here.  Just had a simple check for pass if it is None:

        if result.auth_error is None:
            pass
        else:
            if result.auth_error.error_code == 50053:
                global_lockouts_observed += 1
